### PR TITLE
Fix getDouble() causes MethodCannotBeConfiguredException

### DIFF
--- a/src/TestDouble.php
+++ b/src/TestDouble.php
@@ -67,7 +67,11 @@ trait TestDouble
             }
         }
 
-        $mock = $mockBuilder->onlyMethods($methods)->getMock();
+        if ($methods === []) {
+            $mock = $mockBuilder->getMock();
+        } else {
+            $mock = $mockBuilder->onlyMethods($methods)->getMock();
+        }
 
         foreach ($onConsecutiveCalls as $method => $returns) {
             $mock->expects($this->any())->method($method)

--- a/src/TestDouble.php
+++ b/src/TestDouble.php
@@ -53,19 +53,7 @@ trait TestDouble
             $mockBuilder->setConstructorArgs($constructorParams);
         }
 
-        $methods = [];
-        $onConsecutiveCalls = [];
-        $otherCalls = [];
-
-        foreach ($params as $key => $val) {
-            if (is_int($key)) {
-                $onConsecutiveCalls = array_merge($onConsecutiveCalls, $val);
-                $methods[] = array_keys($val)[0];
-            } else {
-                $otherCalls[$key] = $val;
-                $methods[] = $key;
-            }
-        }
+        [$onConsecutiveCalls, $otherCalls, $methods] = $this->processParams($params);
 
         if ($methods === []) {
             $mock = $mockBuilder->getMock();
@@ -101,6 +89,30 @@ trait TestDouble
         }
 
         return $mock;
+    }
+
+    /**
+     * @param array<string, mixed>|array<array> $params [method_name => return_value]
+     *
+     * @return array{0: array<string, array<string>>, 1: array<string, mixed>, 2: string[]}
+     */
+    private function processParams(array $params): array
+    {
+        $onConsecutiveCalls = [];
+        $otherCalls = [];
+        $methods = [];
+
+        foreach ($params as $key => $val) {
+            if (is_int($key)) {
+                $onConsecutiveCalls = array_merge($onConsecutiveCalls, $val);
+                $methods[] = array_keys($val)[0];
+            } else {
+                $otherCalls[$key] = $val;
+                $methods[] = $key;
+            }
+        }
+
+        return [$onConsecutiveCalls, $otherCalls, $methods];
     }
 
     /**

--- a/tests/Fake/Email.php
+++ b/tests/Fake/Email.php
@@ -10,4 +10,8 @@ class Email
     {
         return $this;
     }
+
+    public function batch_bcc_send(): void
+    {
+    }
 }

--- a/tests/TestDoubleTest.php
+++ b/tests/TestDoubleTest.php
@@ -168,4 +168,12 @@ class TestDoubleTest extends TestCase
 
         $this->verifyNeverInvoked($mock, 'method');
     }
+
+    public function test_create_mock_with_no_params_and_verifyInvokedOnce(): void
+    {
+        $mock = $this->getDouble(Email::class, []);
+        $this->verifyInvokedOnce($mock, 'batch_bcc_send');
+
+        $mock->batch_bcc_send();
+    }
 }


### PR DESCRIPTION
If you write code like this:
```php
$customerInfoRepository = $this->getDouble(CustomerInfoRepository::class, []);
$this->verifyInvokedOnce($customerInfoRepository, 'save');
```

You see the error:
> PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException: Trying to configure method "xxx" which cannot be configured because it does not exist, has not been specified, is final, or is static
